### PR TITLE
Fix typos preventing YTX703F firmware images from being flashed

### DIFF
--- a/YT-X703F_S000744_170824_ROW_firmware/META-INF/com/google/android/updater-script
+++ b/YT-X703F_S000744_170824_ROW_firmware/META-INF/com/google/android/updater-script
@@ -1,10 +1,10 @@
 ###############################################################################
-# Updater script for S000963_171111_ROW firmware
-# Lenovo YT-X703L (Wi-Fi + LTE)
+# Updater script for S000744_170824_ROW firmware
+# Lenovo YT-X703F (Wi-Fi)
 ###############################################################################
-getprop("ro.product.device") == "yt_x703f" || getprop("ro.product.device") == "YTX703F" || abort("E3004: This package is for \"YT-X703L\" devices; this is a \"" + getprop("ro.product.device") + "\".");
+getprop("ro.product.device") == "yt_x703f" || getprop("ro.product.device") == "YTX703F" || abort("E3004: This package is for \"YT-X703F\" devices; this is a \"" + getprop("ro.product.device") + "\".");
 
-ui_print("Flashing stock firmware S000744_170824_ROW onto your YT-X703L.");
+ui_print("Flashing stock firmware S000744_170824_ROW onto your YT-X703F.");
 set_progress(0.01);
 ui_print(" ");
 #

--- a/YT-X703F_S000963_171111_ROW_firmware/META-INF/com/google/android/updater-script
+++ b/YT-X703F_S000963_171111_ROW_firmware/META-INF/com/google/android/updater-script
@@ -2,7 +2,7 @@
 # Updater script for S000963_171111_ROW firmware
 # Lenovo YT-X703F (Wi-Fi only)
 ###############################################################################
-getprop("ro.product.device") == "yt_x703f" || getprop("ro.product.device") == "YTX703F" || abort("E3004: This package is for \"YT-X703L\" devices; this is a \"" + getprop("ro.product.device") + "\".");
+getprop("ro.product.device") == "yt_x703f" || getprop("ro.product.device") == "YTX703F" || abort("E3004: This package is for \"YT-X703F\" devices; this is a \"" + getprop("ro.product.device") + "\".");
 
 ui_print("Flashing stock firmware S000963_171111_ROW onto your YT-X703F.");
 ui_print(" ");

--- a/YT-X703F_S000973_180524_ROW_firmware/META-INF/com/google/android/updater-script
+++ b/YT-X703F_S000973_180524_ROW_firmware/META-INF/com/google/android/updater-script
@@ -2,9 +2,9 @@
 # Updater script for S000973_180524_ROW firmware
 # Lenovo YT-X703F (Wi-Fi only)
 ###############################################################################
-getprop("ro.product.device") == "yt_x703f" || getprop("ro.product.device") == "YTX703F" || abort("E3004: This package is for \"YT-X703L\" devices; this is a \"" + getprop("ro.product.device") + "\".");
+getprop("ro.product.device") == "yt_x703f" || getprop("ro.product.device") == "YTX703F" || abort("E3004: This package is for \"YT-X703F\" devices; this is a \"" + getprop("ro.product.device") + "\".");
 
-ui_print("Flashing stock firmware S000973_1805241139_Q00140_ROW onto your YT-X703L.");
+ui_print("Flashing stock firmware S000973_180524_ROW onto your YT-X703F.");
 ui_print(" ");
 
 show_progress(0.7000, 5);


### PR DESCRIPTION
* YT-X703F_S000973_180524_ROW_firmware: fix name for adspso.bin 
* YTX703F: firmware: fix strings displaying YTX703L 